### PR TITLE
Changed all HTTP links to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
         <title>UdaciFeeds</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:400,100,300,700">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,100,300,700">
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/icomoon.css">
         <link rel="stylesheet" href="css/style.css">
@@ -47,9 +47,9 @@
             </li>
         </script>
 
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-        <script src="http://cdn.jsdelivr.net/handlebarsjs/2.0.0/handlebars.min.js"></script>
-        <script src="http://google.com/jsapi"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/handlebarsjs/2.0.0/handlebars.min.js"></script>
+        <script src="https://google.com/jsapi"></script>
         <script src="js/app.js"></script>
 
         <script src="jasmine/spec/feedreader.js"></script>


### PR DESCRIPTION
Previously, while going to the live version of your repository, the site wouldn't load properly because of "unsafe scripts".
**Reason.** Most links to the JavaScript libraries were `http`.

**What I did.** Keeping rest of the code exactly the same, I changed all the JS links in `index.html` from HTTP to HTTPS. You can view these changes by running a `git diff`.

**Outcome.** The site loads on GitHub Pages without hassle. You can view it [here](https://rafi007akhtar.github.io/Feed-Reader-Testing/).